### PR TITLE
Fix(terminal): Decode HTML entities in `run` command output

### DIFF
--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -202,7 +202,7 @@ class Terminal {
         $engine = new ScriptingEngine();
         $output = $engine->execute($file['content']);
         
-        return ['output' => $output];
+        return ['output' => htmlspecialchars_decode($output, ENT_QUOTES)];
     }
 
     public function getCurrentPath() {


### PR DESCRIPTION
The output of the `run` command was displaying HTML entities (e.g., `&#039;`) instead of their corresponding characters (e.g., `'`).

This was caused by a double-escaping issue. The output from the script engine was already HTML-escaped, and the frontend JavaScript would then escape it a second time before rendering it in the terminal.

This change applies `htmlspecialchars_decode` to the output of the `ScriptingEngine` within the `_commandRun` method in `Terminal.php`. This makes its behavior consistent with the `_commandCat` method, which already decodes its output. The change ensures that raw text is sent to the frontend, which can then safely escape it once, leading to correct rendering.