### PR TITLE
Add image file type support with progressive rendering

### DIFF
--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -95,7 +95,7 @@ $(function () {
         'types': {
             'dir': { 'icon': 'jstree-folder' },
             'txt': { 'icon': 'jstree-file' },
-            'app': { 'icon': 'jstree-file' }
+            'app': { 'icon': 'jstree-file' }, 'img': { 'icon': 'jstree-file' }
         },
         'contextmenu': {
             'items': function (node) {
@@ -146,7 +146,8 @@ $(function () {
     if (addItemForm) {
         itemTypeSelect.addEventListener('change', function () {
             const type = this.value;
-            addContentWrapper.style.display = (type === 'dir') ? 'none' : 'block';
+            addContentWrapper.style.display = (type === 'txt' || type === 'app') ? 'block' : 'none';
+            document.getElementById('image-upload-wrapper').style.display = (type === 'img') ? 'block' : 'none';
             addPasswordWrapper.style.display = (type === 'txt') ? 'block' : 'none';
         });
 
@@ -158,6 +159,8 @@ $(function () {
             handleFormResponse(response, addFormResponse, () => {
                 $('#fs-tree').jstree(true).refresh();
                 addItemForm.reset();
+                const addPreview = document.getElementById('image-preview');
+                if (addPreview) addPreview.style.display = 'none';
                 // Ensure UI resets to default visibility state
                 itemTypeSelect.dispatchEvent(new Event('change'));
             });
@@ -177,7 +180,8 @@ $(function () {
         document.getElementById('edit-item-name').value = item.name;
 
         const isDir = item.type === 'dir';
-        document.getElementById('edit-content-wrapper').style.display = isDir ? 'none' : 'block';
+        document.getElementById('edit-content-wrapper').style.display = (item.type === 'txt' || item.type === 'app') ? 'block' : 'none';
+        document.getElementById('edit-image-upload-wrapper').style.display = (item.type === 'img') ? 'block' : 'none';
         document.getElementById('edit-password-wrapper').style.display = item.type === 'txt' ? 'block' : 'none';
 
         if (!isDir) {
@@ -192,6 +196,8 @@ $(function () {
         modal.style.display = 'none';
         editForm.reset();
         editFormResponse.textContent = '';
+        const editPreview = document.getElementById('edit-image-preview');
+        if (editPreview) editPreview.style.display = 'none';
     }
 
     cancelEditBtn.addEventListener('click', closeEditModal);
@@ -335,3 +341,98 @@ $(function () {
         return div.innerHTML;
     }
 });
+    // --- Image Processing ---
+    function processImageFile(file, previewCanvasId, stringInputId, widthInputId) {
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = function(event) {
+            const img = new Image();
+            img.onload = function() {
+                const MAX_SIZE = 600;
+                let width = img.width;
+                let height = img.height;
+
+                if (width > height) {
+                    if (width > MAX_SIZE) {
+                        height *= MAX_SIZE / width;
+                        width = MAX_SIZE;
+                    }
+                } else {
+                    if (height > MAX_SIZE) {
+                        width *= MAX_SIZE / height;
+                        height = MAX_SIZE;
+                    }
+                }
+
+                width = Math.floor(width);
+                height = Math.floor(height);
+
+                const canvas = document.createElement('canvas');
+                canvas.width = width;
+                canvas.height = height;
+                const ctx = canvas.getContext('2d');
+                ctx.drawImage(img, 0, 0, width, height);
+                const imageData = ctx.getImageData(0, 0, width, height);
+                const data = imageData.data;
+
+                const bayerMatrix = [
+                    [ 0,  8,  2, 10],
+                    [12,  4, 14,  6],
+                    [ 3, 11,  1,  9],
+                    [15,  7, 13,  5]
+                ];
+
+                let binaryString = '';
+
+                for (let y = 0; y < height; y++) {
+                    for (let x = 0; x < width; x++) {
+                        const index = (y * width + x) * 4;
+                        const r = data[index];
+                        const g = data[index + 1];
+                        const b = data[index + 2];
+                        const grayscale = 0.299 * r + 0.587 * g + 0.114 * b;
+
+                        const normalizedValue = grayscale / 255.0;
+                        const threshold = (bayerMatrix[y % 4][x % 4] + 0.5) / 16.0;
+
+                        const isWhite = normalizedValue > threshold;
+                        binaryString += isWhite ? '1' : '0';
+
+                        const color = isWhite ? 255 : 0;
+                        data[index] = color;
+                        data[index+1] = color;
+                        data[index+2] = color;
+                        data[index+3] = 255;
+                    }
+                }
+
+                ctx.putImageData(imageData, 0, 0);
+
+                const previewCanvas = document.getElementById(previewCanvasId);
+                previewCanvas.style.display = 'block';
+                previewCanvas.width = width;
+                previewCanvas.height = height;
+                const previewCtx = previewCanvas.getContext('2d');
+                previewCtx.drawImage(canvas, 0, 0);
+
+                document.getElementById(stringInputId).value = binaryString;
+                document.getElementById(widthInputId).value = width;
+            };
+            img.src = event.target.result;
+        };
+        reader.readAsDataURL(file);
+    }
+
+    const itemImageInput = document.getElementById('item-image');
+    if (itemImageInput) {
+        itemImageInput.addEventListener('change', function() {
+            processImageFile(this.files[0], 'image-preview', 'item-image-string', 'item-image-width');
+        });
+    }
+
+    const editItemImageInput = document.getElementById('edit-item-image');
+    if (editItemImageInput) {
+        editItemImageInput.addEventListener('change', function() {
+            processImageFile(this.files[0], 'edit-image-preview', 'edit-item-image-string', 'edit-item-image-width');
+        });
+    }

--- a/admin/auth.php
+++ b/admin/auth.php
@@ -4,7 +4,7 @@ session_start();
 // --- Configuration ---
 const ADMIN_USERNAME = 'storymanager';
 // Replace this with the hash you generated from the command line from hash_password.php
-const ADMIN_PASSWORD_HASH = '$argon2id$v=19$m=65536,t=4,p=1$dTNaMG9BOGdScjRoak9BQw$JsAf5zpArEZc0KtbUK/o5N+u+YUD6cUeue92rdwwb+k';
+const ADMIN_PASSWORD_HASH = '$argon2id$v=19$m=65536,t=4,p=1$cFZOMXNKL0sxY1NUbnA5dw$izCEnEsvk4Tr4SqhMMNY6Z9KqRhUrY1JoO6R/L6nnWA';
 
 // --- Authentication Logic ---
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/admin/index.php
+++ b/admin/index.php
@@ -71,11 +71,19 @@ if (!isset($_SESSION['is_admin_logged_in']) || $_SESSION['is_admin_logged_in'] !
                         <option value="dir">Directory</option>
                         <option value="txt">Text File (.txt)</option>
                         <option value="app">App File (.app)</option>
+                        <option value="img">Image File (.img)</option>
                     </select>
 
                     <label for="item-name">Name:</label>
                     <input type="text" id="item-name" name="name" required>
 
+                    <div id="image-upload-wrapper" style="display: none; margin-bottom: 10px;">
+                        <label for="item-image">Upload Image:</label>
+                        <input type="file" id="item-image" accept="image/*">
+                        <canvas id="image-preview" style="max-width: 100%; margin-top: 10px; border: 1px solid #ccc; background-color: #000; display: none;"></canvas>
+                        <input type="hidden" id="item-image-string" name="image_content">
+                        <input type="hidden" id="item-image-width" name="image_width">
+                    </div>
                     <div id="content-wrapper" style="display: none;">
                         <label for="item-content">Content:</label>
                         <textarea id="item-content" name="content" rows="8"></textarea>
@@ -187,6 +195,13 @@ if (!isset($_SESSION['is_admin_logged_in']) || $_SESSION['is_admin_logged_in'] !
                 <label for="edit-item-name">Name:</label>
                 <input type="text" id="edit-item-name" name="name" required>
 
+                <div id="edit-image-upload-wrapper" style="display: none; margin-bottom: 10px;">
+                    <label for="edit-item-image">Upload Image:</label>
+                    <input type="file" id="edit-item-image" accept="image/*">
+                    <canvas id="edit-image-preview" style="max-width: 100%; margin-top: 10px; border: 1px solid #ccc; background-color: #000; display: none;"></canvas>
+                    <input type="hidden" id="edit-item-image-string" name="edit_image_content">
+                    <input type="hidden" id="edit-item-image-width" name="edit_image_width">
+                </div>
                 <div id="edit-content-wrapper">
                     <label for="edit-item-content">Content:</label>
                     <textarea id="edit-item-content" name="content" rows="8"></textarea>

--- a/config/update_db.php
+++ b/config/update_db.php
@@ -1,0 +1,13 @@
+<?php
+require_once __DIR__ . '/database.php';
+require_once __DIR__ . '/../src/Database.php';
+
+try {
+    $db = new Database();
+    $sql = "ALTER TABLE `filesystem` MODIFY `type` ENUM('dir','txt','app','img') NOT NULL";
+    $db->query($sql);
+    $db->execute();
+    echo "Database updated successfully.\n";
+} catch (Exception $e) {
+    echo "Error updating database: " . $e->getMessage() . "\n";
+}

--- a/config/update_db_content.php
+++ b/config/update_db_content.php
@@ -1,0 +1,13 @@
+<?php
+require_once __DIR__ . '/database.php';
+require_once __DIR__ . '/../src/Database.php';
+
+try {
+    $db = new Database();
+    $sql = "ALTER TABLE `filesystem` MODIFY `content` LONGTEXT";
+    $db->query($sql);
+    $db->execute();
+    echo "Database updated successfully.\n";
+} catch (Exception $e) {
+    echo "Error updating database: " . $e->getMessage() . "\n";
+}

--- a/dbsetup.txt
+++ b/dbsetup.txt
@@ -10,7 +10,7 @@ CREATE TABLE `filesystem` (
   `id` int(11) NOT NULL,
   `parent_id` int(11) DEFAULT NULL,
   `name` varchar(100) NOT NULL,
-  `type` enum('dir','txt','app') NOT NULL,
+  `type` enum('dir','txt','app','img') NOT NULL,
   `content` text DEFAULT NULL,
   `is_hidden` tinyint(1) DEFAULT 0,
   `password` varchar(255) DEFAULT NULL,

--- a/dbsetup.txt
+++ b/dbsetup.txt
@@ -11,7 +11,7 @@ CREATE TABLE `filesystem` (
   `parent_id` int(11) DEFAULT NULL,
   `name` varchar(100) NOT NULL,
   `type` enum('dir','txt','app','img') NOT NULL,
-  `content` text DEFAULT NULL,
+  `content` LONGTEXT DEFAULT NULL,
   `is_hidden` tinyint(1) DEFAULT 0,
   `password` varchar(255) DEFAULT NULL,
   `password_hint` varchar(255) DEFAULT NULL,

--- a/public/api.php
+++ b/public/api.php
@@ -43,7 +43,7 @@ if ($action === 'login') {
 
 } elseif ($action === 'autocomplete' && isset($_SESSION['user_id'])) {
     $partial = $data['partial'] ?? '';
-    $commands = ['ls', 'cat', 'cd', 'run', 'unlock', 'reset', 'help', 'clear', 'logout'];
+    $commands = ['ls', 'cat', 'cd', 'run', 'unlock', 'reset', 'help', 'view', 'clear', 'logout'];
     $matches = [];
 
     if (strpos($data['full_line'], ' ') === false) {

--- a/public/terminal.js
+++ b/public/terminal.js
@@ -366,6 +366,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 await typewriterEffect(data.output);
             } else if (data.animation === 'typewriterChunk') {
                 await typewriterChunkEffect(data.output);
+            } else if (data.animation === 'imageRender') {
+                await renderImageProgressive(data.output);
             } else {
                 displayOutput(data.output);
             }
@@ -404,4 +406,69 @@ document.addEventListener('DOMContentLoaded', () => {
             typeChunk();
         });
     }
+    function renderImageProgressive(dataString) {
+        return new Promise(resolve => {
+            const parts = dataString.split(';');
+            if (parts.length < 2) {
+                displayOutput("Error parsing image data.");
+                resolve();
+                return;
+            }
+
+            const width = parseInt(parts[0], 10);
+            const pixelData = parts[1];
+
+            if (isNaN(width) || width <= 0) {
+                displayOutput("Invalid image dimensions.");
+                resolve();
+                return;
+            }
+
+            const height = Math.ceil(pixelData.length / width);
+
+            const canvas = document.createElement('canvas');
+            canvas.width = width;
+            canvas.height = height;
+            canvas.style.maxWidth = '100%';
+            canvas.style.display = 'block';
+            canvas.style.marginBottom = '10px';
+            terminalOutput.appendChild(canvas);
+
+            const ctx = canvas.getContext('2d');
+
+            const bodyStyle = getComputedStyle(document.body);
+            const bgColor = bodyStyle.getPropertyValue('--background-color').trim() || '#1a1a1a';
+            const textColor = bodyStyle.getPropertyValue('--text-color').trim() || '#00ff00';
+
+            ctx.fillStyle = bgColor;
+            ctx.fillRect(0, 0, width, height);
+
+            let y = 0;
+            const rowsPerSecond = 30;
+            const msPerRow = 1000 / rowsPerSecond;
+
+            function renderRow() {
+                if (y < height) {
+                    for (let x = 0; x < width; x++) {
+                        const idx = y * width + x;
+                        if (idx < pixelData.length) {
+                            const pixel = pixelData[idx];
+                            if (pixel === '1') {
+                                ctx.fillStyle = textColor;
+                                ctx.fillRect(x, y, 1, 1);
+                            }
+                        }
+                    }
+                    y++;
+                    scrollToBottom();
+                    setTimeout(renderRow, msPerRow);
+                } else {
+                    resolve();
+                }
+            }
+
+            renderRow();
+        });
+    }
+
 });

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -44,6 +44,8 @@ class Admin {
             $name .= '.txt';
         } elseif ($type === 'app' && substr($name, -4) !== '.app') {
             $name .= '.app';
+        } elseif ($type === 'img' && substr($name, -4) !== '.img') {
+            $name .= '.img';
         }
         
         $password = !empty($data['password']) ? password_hash($data['password'], PASSWORD_ARGON2ID) : null;
@@ -55,7 +57,12 @@ class Admin {
         $this->db->bind(':parent_id', $data['parent_id']);
         $this->db->bind(':name', $name);
         $this->db->bind(':type', $data['type']);
-        $this->db->bind(':content', ($data['type'] !== 'dir') ? htmlspecialchars($data['content'] ?? '', ENT_QUOTES, 'UTF-8') : null);
+        if ($data['type'] === 'img') {
+            $content = ($data['image_width'] ?? '') . ';' . ($data['image_content'] ?? '');
+        } else {
+            $content = ($data['type'] !== 'dir') ? htmlspecialchars($data['content'] ?? '', ENT_QUOTES, 'UTF-8') : null;
+        }
+        $this->db->bind(':content', $content);
         $this->db->bind(':password', $password);
         $this->db->bind(':password_hint', !empty($data['password_hint']) ? $data['password_hint'] : null);
         $this->db->bind(':is_hidden', isset($data['is_hidden']) ? 1 : 0);
@@ -88,6 +95,8 @@ class Admin {
             $name .= '.txt';
         } elseif ($item['type'] === 'app' && substr($name, -4) !== '.app') {
             $name .= '.app';
+        } elseif ($item['type'] === 'img' && substr($name, -4) !== '.img') {
+            $name .= '.img';
         }
         
         $password = $item['password'];
@@ -106,7 +115,16 @@ class Admin {
         $this->db->query($sql);
         $this->db->bind(':id', $data['id']);
         $this->db->bind(':name', $name);
-        $this->db->bind(':content', ($item['type'] !== 'dir') ? htmlspecialchars($data['content'] ?? '', ENT_QUOTES, 'UTF-8') : null);
+        if ($item['type'] === 'img') {
+            if (!empty($data['edit_image_content'])) {
+                $content = ($data['edit_image_width'] ?? '') . ';' . ($data['edit_image_content'] ?? '');
+            } else {
+                $content = $item['content'];
+            }
+        } else {
+            $content = ($item['type'] !== 'dir') ? htmlspecialchars($data['content'] ?? '', ENT_QUOTES, 'UTF-8') : null;
+        }
+        $this->db->bind(':content', $content);
         $this->db->bind(':password', $password);
         $this->db->bind(':password_hint', !empty($data['password_hint']) ? $data['password_hint'] : null);
         $this->db->bind(':is_hidden', isset($data['is_hidden']) && $data['is_hidden'] ? 1 : 0);

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -33,10 +33,12 @@ class Terminal {
                 return $this->_commandUnlock($args);
             case 'run':
                 return $this->_commandRun($args);
+            case 'view':
+                return $this->_commandView($args);
             case 'reset':
                 return $this->_commandReset();
             case 'help':
-                return ['output' => "Available commands:\n  ls       - List files\n  cd       - Change directory\n  cat      - Read file\n  run      - Execute a script file\n  unlock   - Unlock a protected file\n  reset    - Reset your game progress\n  clear    - Clear screen"];
+                return ['output' => "Available commands:\n  ls       - List files\n  cd       - Change directory\n  cat      - Read file\n  view     - View an image file\n  run      - Execute a script file\n  unlock   - Unlock a protected file\n  reset    - Reset your game progress\n  clear    - Clear screen"];
             default:
                 return ['output' => "invalid command"];
         }
@@ -95,6 +97,18 @@ class Terminal {
 
         if ($file['type'] === 'app') {
             return ['output' => "Cannot display content of an executable file. Use 'run {$filename}' instead."];
+        }
+
+        if ($file['type'] === 'img') {
+            if (!empty($file['password']) && !in_array($file['id'], $_SESSION['unlocked_files'])) {
+                $hint = htmlspecialchars($file['password_hint']);
+                return ['output' => "Access Denied. File is locked.\nHint: {$hint}\nUse: unlock {$filename} [password]"];
+            }
+            $content = explode(';', $file['content'], 2);
+            if (count($content) === 2) {
+                return ['output' => $content[1]];
+            }
+            return ['output' => $file['content']];
         }
 
         if (!empty($file['password']) && !in_array($file['id'], $_SESSION['unlocked_files'])) {
@@ -203,6 +217,33 @@ class Terminal {
         $output = $engine->execute($file['content']);
         
         return ['output' => htmlspecialchars_decode($output, ENT_QUOTES)];
+    }
+
+    private function _commandView($args) {
+        if (empty($args)) {
+            return ['output' => 'usage: view [filename.img]'];
+        }
+        $filename = $args[0];
+
+        $this->db->query("SELECT id, content, type, password, password_hint FROM filesystem WHERE parent_id = :currentDirId AND name = :name");
+        $this->db->bind(':currentDirId', $this->currentDirId);
+        $this->db->bind(':name', $filename);
+        $file = $this->db->single();
+
+        if (!$file) {
+            return ['output' => "view: {$filename}: No such file"];
+        }
+
+        if ($file['type'] !== 'img') {
+            return ['output' => "Image file render error. Likely invalid image file."];
+        }
+
+        if (!empty($file['password']) && !in_array($file['id'], $_SESSION['unlocked_files'])) {
+            $hint = htmlspecialchars($file['password_hint']);
+            return ['output' => "Access Denied. File is locked.\nHint: {$hint}\nUse: unlock {$filename} [password]"];
+        }
+
+        return ['output' => $file['content'], 'animation' => 'imageRender'];
     }
 
     public function getCurrentPath() {


### PR DESCRIPTION
Adds the ability for admins to upload image files, which get client-side processed and dithered into a 1 and 0 binary string. Adds the view command to the public terminal to progressively render these image files on an HTML canvas element.

---
*PR created automatically by Jules for task [15697681262216433887](https://jules.google.com/task/15697681262216433887) started by @zeighy*