### PR TITLE
feat: Add user permissions to files and directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ It's built with PHP and a MySQL database on the back-end, with a dynamic, vanill
 
 - **Secure Logins:** Separate, secure logins for the administrator and players.
 - **Full Filesystem Manager:** A web UI to create, edit, and delete all files and directories.
+- **User Permissions:** Set access restrictions on files and directories. Assign ownership to a specific player or make it available to "All Users". Files restricted to other users will return "Access Denied" if an unauthorized user attempts to access them.
 - **Full User Manager:** An interface to add, edit, and delete player accounts.
 - **Branding & Theming:** A theme manager to customize the terminal's title, greetings, MOTD, and color scheme.
 

--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -188,6 +188,7 @@ $(function () {
             document.getElementById('edit-item-content').value = item.content || '';
         }
         document.getElementById('edit-is-hidden').checked = item.is_hidden == 1;
+        document.getElementById('edit-item-owner').value = item.owner_id ? item.owner_id : 'null';
 
         modal.style.display = 'flex';
     }
@@ -228,6 +229,26 @@ $(function () {
     // ============================
     // USER MANAGEMENT LOGIC
     // ============================
+
+    async function loadUserDropdowns() {
+        const result = await apiRequest('get_users');
+        if (result.success) {
+            const addOwnerSelect = document.getElementById('item-owner');
+            const editOwnerSelect = document.getElementById('edit-item-owner');
+
+            let optionsHtml = '<option value="null">All Users</option>';
+            result.data.forEach(user => {
+                optionsHtml += `<option value="${user.id}">${escapeHtml(user.username)}</option>`;
+            });
+
+            if (addOwnerSelect) addOwnerSelect.innerHTML = optionsHtml;
+            if (editOwnerSelect) editOwnerSelect.innerHTML = optionsHtml;
+        }
+    }
+
+    // Load on start
+    loadUserDropdowns();
+
     const userForm = document.getElementById('user-form');
     const userFormTitle = document.getElementById('user-form-title');
     const userIdInput = document.getElementById('user-id');

--- a/admin/index.php
+++ b/admin/index.php
@@ -100,6 +100,11 @@ if (!isset($_SESSION['is_admin_logged_in']) || $_SESSION['is_admin_logged_in'] !
                         <input type="checkbox" id="is-hidden" name="is_hidden" value="1"> Hidden File
                     </label>
 
+                    <label for="item-owner">Owner (Optional):</label>
+                    <select id="item-owner" name="owner_id">
+                        <option value="">All Users</option>
+                    </select>
+
                     <button type="submit">Add Item</button>
                 </form>
                 <div id="form-response"></div>
@@ -217,6 +222,11 @@ if (!isset($_SESSION['is_admin_logged_in']) || $_SESSION['is_admin_logged_in'] !
                 <label class="checkbox-label">
                     <input type="checkbox" id="edit-is-hidden" name="is_hidden" value="1"> Hidden File
                 </label>
+
+                <label for="edit-item-owner">Owner (Optional):</label>
+                <select id="edit-item-owner" name="owner_id">
+                    <option value="">All Users</option>
+                </select>
 
                 <div class="modal-actions">
                     <button type="submit">Save Changes</button>

--- a/config/update_owner.php
+++ b/config/update_owner.php
@@ -1,0 +1,21 @@
+<?php
+require_once __DIR__ . '/database.php';
+require_once __DIR__ . '/../src/Database.php';
+
+try {
+    $db = new Database();
+
+    // Change owner_id to allow NULL and set default to NULL
+    $sql1 = "ALTER TABLE `filesystem` MODIFY `owner_id` int(11) DEFAULT NULL";
+    $db->query($sql1);
+    $db->execute();
+
+    // Set existing records to NULL (All users)
+    $sql2 = "UPDATE `filesystem` SET `owner_id` = NULL";
+    $db->query($sql2);
+    $db->execute();
+
+    echo "Database updated successfully.\n";
+} catch (Exception $e) {
+    echo "Error updating database: " . $e->getMessage() . "\n";
+}

--- a/dbsetup.txt
+++ b/dbsetup.txt
@@ -15,14 +15,14 @@ CREATE TABLE `filesystem` (
   `is_hidden` tinyint(1) DEFAULT 0,
   `password` varchar(255) DEFAULT NULL,
   `password_hint` varchar(255) DEFAULT NULL,
-  `owner_id` int(11) DEFAULT 1
+  `owner_id` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `filesystem`
 --
 INSERT INTO `filesystem` (`id`, `parent_id`, `name`, `type`, `content`, `is_hidden`, `password`, `password_hint`, `owner_id`) VALUES
-(1, NULL, '/', 'dir', NULL, 0, NULL, NULL, 1);
+(1, NULL, '/', 'dir', NULL, 0, NULL, NULL, NULL);
 
 -- --------------------------------------------------------
 

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -51,7 +51,7 @@ class Admin {
         $password = !empty($data['password']) ? password_hash($data['password'], PASSWORD_ARGON2ID) : null;
         
         $sql = "INSERT INTO filesystem (parent_id, name, type, content, password, password_hint, is_hidden, owner_id) 
-                VALUES (:parent_id, :name, :type, :content, :password, :password_hint, :is_hidden, 1)";
+                VALUES (:parent_id, :name, :type, :content, :password, :password_hint, :is_hidden, :owner_id)";
                 
         $this->db->query($sql);
         $this->db->bind(':parent_id', $data['parent_id']);
@@ -66,6 +66,8 @@ class Admin {
         $this->db->bind(':password', $password);
         $this->db->bind(':password_hint', !empty($data['password_hint']) ? $data['password_hint'] : null);
         $this->db->bind(':is_hidden', isset($data['is_hidden']) ? 1 : 0);
+        $owner_id = (!empty($data['owner_id']) && $data['owner_id'] !== 'null') ? $data['owner_id'] : null;
+        $this->db->bind(':owner_id', $owner_id);
 
         try {
             if ($this->db->execute()) {
@@ -109,7 +111,8 @@ class Admin {
                     content = :content, 
                     password = :password, 
                     password_hint = :password_hint, 
-                    is_hidden = :is_hidden
+                    is_hidden = :is_hidden,
+                    owner_id = :owner_id
                 WHERE id = :id";
         
         $this->db->query($sql);
@@ -128,6 +131,8 @@ class Admin {
         $this->db->bind(':password', $password);
         $this->db->bind(':password_hint', !empty($data['password_hint']) ? $data['password_hint'] : null);
         $this->db->bind(':is_hidden', isset($data['is_hidden']) && $data['is_hidden'] ? 1 : 0);
+        $owner_id = (!empty($data['owner_id']) && $data['owner_id'] !== 'null') ? $data['owner_id'] : null;
+        $this->db->bind(':owner_id', $owner_id);
 
         if ($this->db->execute()) {
             return ['success' => true, 'message' => 'Item updated successfully!'];

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -17,6 +17,14 @@ class Terminal {
         }
     }
 
+
+    private function _checkPermission($fileOwnerId) {
+        if ($fileOwnerId === null) {
+            return true;
+        }
+        return $fileOwnerId == $this->userId;
+    }
+
     public function executeCommand($commandStr) {
         $parts = preg_split('/\s+/', $commandStr, -1, PREG_SPLIT_NO_EMPTY);
         $command = strtolower(array_shift($parts));
@@ -82,7 +90,7 @@ class Terminal {
         }
         $filename = $args[0];
 
-        $this->db->query("SELECT id, content, type, password, password_hint FROM filesystem WHERE parent_id = :currentDirId AND name = :name");
+        $this->db->query("SELECT id, content, type, password, password_hint, owner_id FROM filesystem WHERE parent_id = :currentDirId AND name = :name");
         $this->db->bind(':currentDirId', $this->currentDirId);
         $this->db->bind(':name', $filename);
         $file = $this->db->single();
@@ -91,6 +99,10 @@ class Terminal {
             return ['output' => "cat: {$filename}: No such file or directory"];
         }
         
+        if (!$this->_checkPermission($file['owner_id'])) {
+            return ['output' => "Access Denied. No user permission."];
+        }
+
         if ($file['type'] === 'dir') {
             return ['output' => "cat: {$filename}: Is a directory"];
         }
@@ -141,12 +153,15 @@ class Terminal {
                 $_SESSION['current_directory_id'] = $current['parent_id'];
             }
         } else {
-            $this->db->query("SELECT id FROM filesystem WHERE parent_id = :currentDirId AND name = :name AND type = 'dir'");
+            $this->db->query("SELECT id, owner_id FROM filesystem WHERE parent_id = :currentDirId AND name = :name AND type = 'dir'");
             $this->db->bind(':currentDirId', $this->currentDirId);
             $this->db->bind(':name', $targetDirName);
             $target = $this->db->single();
 
             if ($target) {
+                if (!$this->_checkPermission($target['owner_id'])) {
+                    return ['output' => "cd: " . htmlspecialchars($targetDirName) . ": Access Denied. No user permission."];
+                }
                 $_SESSION['current_directory_id'] = $target['id'];
             } else {
                 return ['output' => "cd: " . htmlspecialchars($targetDirName) . ": No such directory"];
@@ -161,7 +176,7 @@ class Terminal {
         }
         $filename = $args[0];
 
-        $this->db->query("SELECT id, password FROM filesystem WHERE parent_id = :currentDirId AND name = :name");
+        $this->db->query("SELECT id, password, owner_id FROM filesystem WHERE parent_id = :currentDirId AND name = :name");
         $this->db->bind(':currentDirId', $this->currentDirId);
         $this->db->bind(':name', $filename);
         $file = $this->db->single();
@@ -170,6 +185,10 @@ class Terminal {
             return ['output' => "unlock: {$filename}: No such file."];
         }
         
+        if (!$this->_checkPermission($file['owner_id'])) {
+            return ['output' => "Access Denied. No user permission."];
+        }
+
         if (empty($file['password'])) {
             return ['output' => "File is not password protected."];
         }
@@ -204,13 +223,17 @@ class Terminal {
             $_SESSION['run_input'] = null;
         }
 
-        $this->db->query("SELECT content FROM filesystem WHERE parent_id = :currentDirId AND name = :name AND type = 'app'");
+        $this->db->query("SELECT content, owner_id FROM filesystem WHERE parent_id = :currentDirId AND name = :name AND type = 'app'");
         $this->db->bind(':currentDirId', $this->currentDirId);
         $this->db->bind(':name', $filename);
         $file = $this->db->single();
 
         if (!$file) {
             return ['output' => "run: {$filename}: No such executable file"];
+        }
+
+        if (!$this->_checkPermission($file['owner_id'])) {
+            return ['output' => "Access Denied. No user permission."];
         }
 
         $engine = new ScriptingEngine();
@@ -225,13 +248,17 @@ class Terminal {
         }
         $filename = $args[0];
 
-        $this->db->query("SELECT id, content, type, password, password_hint FROM filesystem WHERE parent_id = :currentDirId AND name = :name");
+        $this->db->query("SELECT id, content, type, password, password_hint, owner_id FROM filesystem WHERE parent_id = :currentDirId AND name = :name");
         $this->db->bind(':currentDirId', $this->currentDirId);
         $this->db->bind(':name', $filename);
         $file = $this->db->single();
 
         if (!$file) {
             return ['output' => "view: {$filename}: No such file"];
+        }
+
+        if (!$this->_checkPermission($file['owner_id'])) {
+            return ['output' => "Access Denied. No user permission."];
         }
 
         if ($file['type'] !== 'img') {


### PR DESCRIPTION
Adds the ability to restrict access to files and directories to a specific user. Updates the `filesystem` table with a nullable `owner_id`. If `owner_id` is null, the item is available to "All Users". The Admin Panel includes an "Owner" dropdown when creating and editing items. `Terminal.php` restricts access during `cat`, `cd`, `unlock`, `view`, and `run` commands if the current user ID does not match the item's `owner_id` (except when `owner_id` is null). Included an `update_owner.php` migration script and updated the `README.md`.

---
*PR created automatically by Jules for task [13321995413213309292](https://jules.google.com/task/13321995413213309292) started by @zeighy*