### PR TITLE
Add FETCH Command for external data retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ As a player, your goal is to explore the pseudo-filesystem and uncover secrets.
 **Quality of Life Features**
 
 - **Command History**: Use the **Up** and **Down** arrow keys.
-- **Tab Autocomplete**: Press the **Tab** key to complete commands and filenames. A triple backtick (\`\`\`) or triple comma (,,,) can also be used for auto complete on devices with no tab key.
+- **Tab Autocomplete**: Press the **Tab** key to complete commands and filenames. A triple comma (,,,) can also be used for auto complete on devices with no tab key.
 
 **Important Note on Progress**
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ The heart of your interactive story is the scripting engine. This guide explains
 - **CALC \[variable_name\] = \[value1\] \[operator\] \[value2\]**: Performs a math operation (+, -, \*, /).
 - **WAIT \[milliseconds\]**: Pauses the script.
 - **IF \[condition\] / ELSE / ENDIF**: Controls the flow of your script.
+- **FETCH \[variable_name\] = \[URL\]**: Fetches data from a fixed URL endpoint. The endpoint must return JSON containing a "value" field. The value is sanitized to only allow alphanumeric characters and then stored in the specified variable. On error (connection issue, missing "value" field, etc.), the variable is set to an empty string ("").
+
+> **Note on FETCH:** You can also use `FETCH` to ping a URL (e.g., to count how many times a script has run). The server should still return JSON with a `value` field (like `{"value": "OK"}`) for the script to successfully proceed. You can then optionally reset the variable on the next line using `SET [variable_name] = ""`.
 
 **Variables Explained**
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ As a player, your goal is to explore the pseudo-filesystem and uncover secrets.
 - **cat \[filename\]**: Displays a text file's contents.
 - **run \[appname.app\]**: Executes a script aka ‘program’.
 - **unlock \[filename\] \[password\]**: Unlocks a protected file.
+- **view \[filename\]**: Views an image file.
 - **reset**: Resets all your progress.
 - **help**: Displays available commands.
 - **clear**: Clears the screen.
@@ -149,7 +150,7 @@ As a player, your goal is to explore the pseudo-filesystem and uncover secrets.
 **Quality of Life Features**
 
 - **Command History**: Use the **Up** and **Down** arrow keys.
-- **Tab Autocomplete**: Press the **Tab** key to complete commands and filenames.
+- **Tab Autocomplete**: Press the **Tab** key to complete commands and filenames. A triple backtick (\`\`\`) or triple comma (,,,) can also be used for auto complete on devices with no tab key.
 
 **Important Note on Progress**
 

--- a/src/ScriptingEngine.php
+++ b/src/ScriptingEngine.php
@@ -62,6 +62,40 @@ class ScriptingEngine {
             case 'WAIT':
                 $this->output .= "%%WAIT:" . intval($args) . "%%\n";
                 break;
+            case 'FETCH':
+                $this->handleFetch($args);
+                break;
+        }
+    }
+
+    private function handleFetch($args) {
+        $parts = explode('=', $args, 2);
+        if (count($parts) === 2) {
+            $varName = trim($parts[0]);
+            $url = trim($parts[1]);
+
+            $context = stream_context_create([
+                'http' => [
+                    'timeout' => 20
+                ],
+                'ssl' => [
+                    'timeout' => 20
+                ]
+            ]);
+
+            $result = @file_get_contents($url, false, $context);
+
+            $finalValue = "";
+            if ($result !== false) {
+                $data = @json_decode($result, true);
+                if (is_array($data) && isset($data['value'])) {
+                    // Sanitize by removing all non-alphanumeric characters
+                    $sanitizedValue = preg_replace('/[^a-zA-Z0-9]/', '', (string)$data['value']);
+                    $finalValue = is_numeric($sanitizedValue) ? (float)$sanitizedValue : $sanitizedValue;
+                }
+            }
+
+            $this->variables[$varName] = $finalValue;
         }
     }
 


### PR DESCRIPTION
Implemented the `FETCH [variable] = [URL]` command in the `ScriptingEngine` class. It uses PHP's `file_get_contents` to fetch the given URL endpoint, parses the returned JSON for a "value" field, and sanitizes the result to ensure it is purely alphanumeric. The value is then assigned to the scripting engine variables just like `SET`. In case of a connection issue or missing field, an empty string is set instead. The `README.md` was also updated with clear documentation on how to use `FETCH`, including a note regarding using it to ping external endpoints for tracking purposes.

---
*PR created automatically by Jules for task [11994020216527525385](https://jules.google.com/task/11994020216527525385) started by @zeighy*