### PR TITLE
Fix admin file explorer hover actions, add delete warning context, and support locked images

### DIFF
--- a/admin/assets/admin.css
+++ b/admin/assets/admin.css
@@ -401,6 +401,12 @@ table tr:hover {
     transform: translateY(-2px);
 }
 
+.fs-item.selected {
+    background-color: var(--item-hover-bg);
+    border-color: var(--primary-color);
+    box-shadow: 0 0 5px rgba(0,123,255,0.5);
+}
+
 .fs-item-icon {
     font-size: 3rem;
     margin-bottom: 10px;

--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -140,9 +140,7 @@ $(function () {
                     'delete': {
                         'label': 'Delete',
                         'action': function () {
-                            if (confirm('Are you sure you want to delete this item? This cannot be undone.')) {
-                                deleteItem(node.id);
-                            }
+                            triggerDelete(node.id, node.text);
                         }
                     }
                 };
@@ -181,7 +179,7 @@ $(function () {
             const type = this.value;
             addContentWrapper.style.display = (type === 'txt' || type === 'app') ? 'block' : 'none';
             document.getElementById('image-upload-wrapper').style.display = (type === 'img') ? 'block' : 'none';
-            addPasswordWrapper.style.display = (type === 'txt') ? 'block' : 'none';
+            addPasswordWrapper.style.display = (type === 'txt' || type === 'img') ? 'block' : 'none';
         });
 
         addItemForm.addEventListener('submit', async function (e) {
@@ -215,7 +213,7 @@ $(function () {
         const isDir = item.type === 'dir';
         document.getElementById('edit-content-wrapper').style.display = (item.type === 'txt' || item.type === 'app') ? 'block' : 'none';
         document.getElementById('edit-image-upload-wrapper').style.display = (item.type === 'img') ? 'block' : 'none';
-        document.getElementById('edit-password-wrapper').style.display = item.type === 'txt' ? 'block' : 'none';
+        document.getElementById('edit-password-wrapper').style.display = (item.type === 'txt' || item.type === 'img') ? 'block' : 'none';
 
         if (!isDir) {
             document.getElementById('edit-item-content').value = item.content || '';
@@ -498,9 +496,15 @@ $(function () {
 
 // --- Modern File Explorer Logic ---
 
+let selectedFileId = null;
+let selectedFileName = null;
+
 async function renderMainView(directoryId) {
     const mainView = document.getElementById('fs-main-view');
     const currentPathEl = document.getElementById('fs-current-path');
+
+    // Clear selection state when navigating
+    clearSelection();
 
     mainView.innerHTML = '<p>Loading...</p>';
 
@@ -531,14 +535,28 @@ async function renderMainView(directoryId) {
                     const iconChar = isDir ? '📁' : '📄';
                     const itemEl = document.createElement('div');
                     itemEl.className = 'fs-item ' + (isDir ? 'dir' : 'file');
+                    itemEl.dataset.id = item.id;
+                    itemEl.dataset.name = item.text;
                     itemEl.innerHTML = `
                         <div class="fs-item-icon">${iconChar}</div>
                         <div class="fs-item-name">${escapeHtml(item.text)}</div>
-                        <div class="fs-item-actions">
-                            <button class="fs-item-btn fs-btn-edit" data-id="${item.id}" onclick="event.stopPropagation(); triggerEdit('${item.id}')">Edit</button>
-                            <button class="fs-item-btn fs-btn-delete" data-id="${item.id}" onclick="event.stopPropagation(); triggerDelete('${item.id}')">Del</button>
-                        </div>
                     `;
+
+                    itemEl.addEventListener('click', (e) => {
+                        e.stopPropagation();
+
+                        // Clear previous selection visually
+                        const prevSelected = document.querySelector('.fs-item.selected');
+                        if (prevSelected) {
+                            prevSelected.classList.remove('selected');
+                        }
+
+                        itemEl.classList.add('selected');
+                        selectedFileId = item.id;
+                        selectedFileName = item.text;
+
+                        document.getElementById('fs-main-actions').style.display = 'flex';
+                    });
 
                     if (isDir) {
                         itemEl.addEventListener('dblclick', () => {
@@ -563,6 +581,35 @@ async function renderMainView(directoryId) {
          console.error(e);
     }
 }
+
+function clearSelection() {
+    selectedFileId = null;
+    selectedFileName = null;
+    document.getElementById('fs-main-actions').style.display = 'none';
+    const selectedItem = document.querySelector('.fs-item.selected');
+    if (selectedItem) {
+        selectedItem.classList.remove('selected');
+    }
+}
+
+// Clear selection when clicking empty area in main view
+document.querySelector('.filesystem-main').addEventListener('click', () => {
+    clearSelection();
+});
+
+document.getElementById('main-edit-btn').addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (selectedFileId) {
+        triggerEdit(selectedFileId);
+    }
+});
+
+document.getElementById('main-delete-btn').addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (selectedFileId && selectedFileName) {
+        triggerDelete(selectedFileId, selectedFileName);
+    }
+});
 
 async function triggerPreview(id) {
     const item = await apiRequest('get_item', { id: id });
@@ -644,8 +691,9 @@ function triggerEdit(id) {
     }
 }
 
-function triggerDelete(id) {
-    if(confirm('Are you sure you want to delete this item? This cannot be undone.')) {
+function triggerDelete(id, name) {
+    const itemName = name ? `"${name}"` : 'this item';
+    if(confirm(`Are you sure you want to delete ${itemName}? This cannot be undone.`)) {
         deleteItem(id);
     }
 }

--- a/admin/index.php
+++ b/admin/index.php
@@ -83,8 +83,12 @@ foreach ($themeResults as $row) {
                 <div id="fs-tree" style="overflow-y: auto; max-height: calc(80vh - 60px);"></div>
             </div>
             <div class="filesystem-main">
-                <div class="fs-main-header">
-                    <h2 id="fs-current-path">/</h2>
+                <div class="fs-main-header" style="display: flex; justify-content: space-between; align-items: center;">
+                    <h2 id="fs-current-path" style="margin: 0;">/</h2>
+                    <div id="fs-main-actions" style="display: none; gap: 10px;">
+                        <button type="button" id="main-edit-btn" class="action-btn" style="background-color: var(--warning-color); color: #333; font-size: 1rem; padding: 5px 15px; margin: 0;">Edit</button>
+                        <button type="button" id="main-delete-btn" class="action-btn" style="background-color: var(--danger-color); font-size: 1rem; padding: 5px 15px; margin: 0;">Delete</button>
+                    </div>
                 </div>
                 <div id="fs-main-view" class="fs-grid-view">
                     <!-- Loaded dynamically via JS -->


### PR DESCRIPTION
- Removed inline Edit and Delete buttons on individual file system items.
- Added static, global Edit and Delete buttons inside `.fs-main-header`.
- Implemented file selection logic (single click) that highlights the item with a `.selected` class and enables the global action buttons.
- Updated `triggerDelete` to take the item name and include it in the confirmation prompt, updating the jsTree context menu as well.
- Modified the Add and Edit item UI to display the Password/Hint wrapper fields when an Image (`.img`) file is selected, allowing password protection natively supported by the backend `view` command.

---
*PR created automatically by Jules for task [11192324345450450855](https://jules.google.com/task/11192324345450450855) started by @zeighy*